### PR TITLE
File association "There's no active .glsl editor"

### DIFF
--- a/out/extension.js
+++ b/out/extension.js
@@ -36,7 +36,7 @@ function activate(context) {
 exports.activate = activate;
 function currentGlslEditor() {
     const editor = vscode.window.activeTextEditor;
-	return editor && (editor.document.languageId === 'glsl' || editor.document.languageId === 'cpp' || editor.document.languageId === 'c') ? editor : null; // || editor.document.languageId === 'plaintext'
+	return editor && (String(editor.document.fileName).split('.').pop() === "glsl") ? editor : null; // || editor.document.languageId === 'plaintext'
 }
 function currentGlslDocument() {
     const editor = currentGlslEditor();

--- a/out/extension.js
+++ b/out/extension.js
@@ -36,7 +36,7 @@ function activate(context) {
 exports.activate = activate;
 function currentGlslEditor() {
     const editor = vscode.window.activeTextEditor;
-    return editor && (editor.document.languageId === 'glsl') ? editor : null; // || editor.document.languageId === 'plaintext'
+	return editor && (editor.document.languageId === 'glsl' || editor.document.languageId === 'cpp' || editor.document.languageId === 'c') ? editor : null; // || editor.document.languageId === 'plaintext'
 }
 function currentGlslDocument() {
     const editor = currentGlslEditor();


### PR DESCRIPTION
To get intellisense to work with glsl, I included glm into my cpp workspace. However, I have to tell vscode to treat glsl files like cpp files with this in my settings.json
```
"files.associations": {
	"*.glsl": "cpp"
}
```
To get this to work with glsl-canvas, I check with the file extension instead.